### PR TITLE
Add support for ShardKey, SortKey and PersistedColumn

### DIFF
--- a/sqlalchemy_singlestoredb/__init__.py
+++ b/sqlalchemy_singlestoredb/__init__.py
@@ -40,6 +40,9 @@ from sqlalchemy.dialects.mysql.dml import Insert
 from sqlalchemy.dialects.mysql.dml import insert
 
 from . import base
+from .column import PersistedColumn
+from .ddlelement import ShardKey
+from .ddlelement import SortKey
 from .dtypes import JSON
 from .dtypes import VECTOR
 
@@ -74,8 +77,11 @@ __all__ = (
     'NCHAR',
     'NVARCHAR',
     'NUMERIC',
+    'PersistedColumn',
     'SET',
     'SMALLINT',
+    'ShardKey',
+    'SortKey',
     'REAL',
     'TEXT',
     'TIME',

--- a/sqlalchemy_singlestoredb/base.py
+++ b/sqlalchemy_singlestoredb/base.py
@@ -26,11 +26,13 @@ from sqlalchemy.engine.url import URL
 from sqlalchemy.sql import sqltypes
 from sqlalchemy.sql.compiler import BIND_PARAMS
 from sqlalchemy.sql.compiler import BIND_PARAMS_ESC
+from sqlalchemy.sql.schema import SchemaConst
 
 from . import reflection
-from .dtypes import _json_deserializer
+from .column import PersistedColumn
 from .dtypes import JSON
 from .dtypes import VECTOR
+from .dtypes import _json_deserializer
 
 
 class CaseInsensitiveDict(Dict[str, Any]):
@@ -197,6 +199,71 @@ class SingleStoreDBCompiler(MySQLCompiler):
 
 class SingleStoreDBDDLCompiler(MySQLDDLCompiler):
     """SingleStoreDB SQLAlchemy DDL compiler."""
+    def visit_create_table(self, create, **kw):
+        create_table_sql = super().visit_create_table(create, **kw)
+        shard_key = create.element.info.get('singlestoredb_shard_key')
+        if shard_key is not None:
+            shard_columns = ", ".join(shard_key.columns)
+            shard_key_sql = f"SHARD KEY ({shard_columns})"
+            # Append the SHARD KEY definition to the original SQL
+            create_table_sql = f"{create_table_sql.rstrip()[:-2]},\n\t{shard_key_sql}\n)"
+
+        sort_key = create.element.info.get('singlestoredb_sort_key')
+        if sort_key is not None:
+            sort_columns = ", ".join(sort_key.columns)
+            sort_key_sql = f"SORT KEY ({sort_columns})"
+            # Append the SHARD KEY definition to the original SQL
+            create_table_sql = f"{create_table_sql.rstrip()[:-2]},\n\t{sort_key_sql}\n)"
+
+        return create_table_sql
+
+    def get_column_specification(self, column, **kw):
+        """Builds column DDL."""
+        if not isinstance(column, PersistedColumn):
+            return super().get_column_specification(column, **kw)
+
+        if (
+            self.dialect.is_mariadb is True
+            and column.computed is not None
+            and column._user_defined_nullable is SchemaConst.NULL_UNSPECIFIED
+        ):
+            column.nullable = True
+        colspec = [
+            self.preparer.format_column(column),
+            "AS",
+            column.persisted_expression,
+            "PERSISTED",
+            self.dialect.type_compiler_instance.process(
+                column.type, type_expression=column
+            ),
+        ]
+
+        if column.computed is not None:
+            colspec.append(self.process(column.computed))
+
+        is_timestamp = isinstance(
+            column.type._unwrapped_dialect_impl(self.dialect),
+            sqltypes.TIMESTAMP,
+        )
+
+        if not column.nullable:
+            colspec.append("NOT NULL")
+
+        # see: https://docs.sqlalchemy.org/en/latest/dialects/mysql.html#mysql_timestamp_null  # noqa
+        elif column.nullable and is_timestamp:
+            colspec.append("NULL")
+
+        comment = column.comment
+        if comment is not None:
+            literal = self.sql_compiler.render_literal_value(
+                comment, sqltypes.String()
+            )
+            colspec.append("COMMENT " + literal)
+
+        default = self.get_column_default_string(column)
+        if default is not None:
+            colspec.append("DEFAULT " + default)
+        return " ".join(colspec)
 
 
 class SingleStoreDBTypeCompiler(MySQLTypeCompiler):

--- a/sqlalchemy_singlestoredb/column.py
+++ b/sqlalchemy_singlestoredb/column.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, text
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.sql.expression import TextClause
+
+Base = declarative_base()
+
+
+class PersistedColumn(Column):
+    def __init__(self, *args, persisted_expression=None, **kwargs):
+        if persisted_expression is not None:
+            # Ensure persisted_expression is either a TextClause or a string
+            if not isinstance(persisted_expression, (TextClause, str)):
+                raise ValueError("Persisted expression must be a SQL expression as a string or TextClause")
+            self.is_persisted = True
+            self.persisted_expression = persisted_expression
+            kwargs["info"] = {"persisted_expression": persisted_expression}
+        super().__init__(*args, **kwargs)

--- a/sqlalchemy_singlestoredb/ddlelement.py
+++ b/sqlalchemy_singlestoredb/ddlelement.py
@@ -1,0 +1,26 @@
+from sqlalchemy import event, Table, DDL
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.schema import DDLElement
+
+Base = declarative_base()
+
+
+class ShardKey(DDLElement):
+    def __init__(self, *columns):
+        self.columns = columns
+
+
+@compiles(ShardKey, 'singlestoredb.mysql')
+def compile_shard_key(element, compiler, **kw):
+    return "SHARD KEY (%s)" % ', '.join(element.columns)
+
+
+class SortKey(DDLElement):
+    def __init__(self, *columns):
+        self.columns = columns
+
+
+@compiles(SortKey, 'singlestoredb.mysql')
+def compile_sort_key(element, compiler, **kw):
+    return "SORT KEY (%s)" % ', '.join(element.columns)

--- a/sqlalchemy_singlestoredb/examples/universal/main.py
+++ b/sqlalchemy_singlestoredb/examples/universal/main.py
@@ -1,0 +1,46 @@
+"""
+Example that uses ShardKey, SortKey and PersistedColumn in one table definition
+Utilizes mock engine to run without actual connection to database
+"""
+from singlestoredb.alchemy import create_engine
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import declarative_base
+
+from sqlalchemy_singlestoredb import PersistedColumn, ShardKey, SortKey
+
+Base = declarative_base()
+
+
+# Creating mock engine as suggested by the SQLAlchemy docs
+# https://docs.sqlalchemy.org/en/20/faq/metadata_schema.html#how-can-i-get-the-create-table-drop-table-output-as-a-string
+def dump(sql, *multiparams, **params):
+    print(sql.compile(dialect=mock_engine.dialect))
+
+
+mock_engine = create_engine("singlestoredb://host:3306", strategy='mock', executor=dump)
+
+
+# Example model using PersistedColumn with a computed expression
+class MyTable(Base):
+    __tablename__ = 'my_new_table'
+
+    id = Column(Integer, primary_key=True)
+    data = Column(String(50))
+    data_length = PersistedColumn(Integer, persisted_expression="LENGTH(data)")
+
+    __table_args__ = (
+        {
+            "info": {
+                "singlestoredb_shard_key": ShardKey('id'),
+                "singlestoredb_sort_key": SortKey('id', 'data')
+            }
+        }
+    )
+
+
+def main():
+    Base.metadata.create_all(mock_engine, checkfirst=False)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This package lacks a lot of core SingleStore functionality. 

This pull request adds simple support for the ShardKey, SortKey and PersistedColumn to the SQLAlchemy's `create_table`