### PR TITLE
remove unused declarative_base

### DIFF
--- a/sqlalchemy_singlestoredb/column.py
+++ b/sqlalchemy_singlestoredb/column.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from sqlalchemy import Column
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.sql.expression import TextClause
-
-Base = declarative_base()
 
 
 class PersistedColumn(Column):

--- a/sqlalchemy_singlestoredb/ddlelement.py
+++ b/sqlalchemy_singlestoredb/ddlelement.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.schema import DDLElement
-
-Base = declarative_base()
 
 
 class ShardKey(DDLElement):


### PR DESCRIPTION
After upgrading sqlalchemy-singlestoredb to 1.1.0, the following warning appears:
```
sqlalchemy.exc.MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
```
It seems that `declarative_base` is unused in the sources, so we can remove them safely.