### PR TITLE
[docs] Fix plural table argument names in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ class Document(Base):
 
     __table_args__ = {
         'singlestoredb_table_type': ColumnStore(),
-        'singlestoredb_vector_keys': [
+        'singlestoredb_vector_key': [
             VectorKey('embedding', index_options={'metric_type': 'COSINE_SIMILARITY'}),
         ],
     }

--- a/docs/_sources/getting-started.rst.txt
+++ b/docs/_sources/getting-started.rst.txt
@@ -56,10 +56,10 @@ Use SQLAlchemy's Table construct with SingleStoreDB-specific options:
         Column('tags', JSON),
         singlestoredb_table_type=ColumnStore(),
         singlestoredb_shard_key=ShardKey('id'),
-        singlestoredb_vector_keys=[
+        singlestoredb_vector_key=[
             VectorKey('embedding', index_options={'metric_type': 'COSINE_SIMILARITY'}),
         ],
-        singlestoredb_multi_value_indexes=[MultiValueIndex('tags')],
+        singlestoredb_multi_value_index=[MultiValueIndex('tags')],
     )
     # Create all tables
     metadata.create_all(engine)
@@ -98,10 +98,10 @@ Use SQLAlchemy's declarative ORM with ``__table_args__``:
         __table_args__ = {
             'singlestoredb_table_type': ColumnStore(),
             'singlestoredb_shard_key': ShardKey('id'),
-            'singlestoredb_vector_keys': [
+            'singlestoredb_vector_key': [
                 VectorKey('embedding', index_options={'metric_type': 'COSINE_SIMILARITY'}),
             ],
-            'singlestoredb_multi_value_indexes': [MultiValueIndex('tags')],
+            'singlestoredb_multi_value_index': [MultiValueIndex('tags')],
         }
     # Create all tables
     Base.metadata.create_all(engine)

--- a/docs/generated/sqlalchemy_singlestoredb.FullTextIndex.html
+++ b/docs/generated/sqlalchemy_singlestoredb.FullTextIndex.html
@@ -140,7 +140,7 @@ Version 2 or higher requires explicit specification.</p></li>
     <span class="s1">&#39;articles&#39;</span><span class="p">,</span> <span class="n">metadata</span><span class="p">,</span>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;id&#39;</span><span class="p">,</span> <span class="n">Integer</span><span class="p">,</span> <span class="n">primary_key</span><span class="o">=</span><span class="kc">True</span><span class="p">),</span>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;content&#39;</span><span class="p">,</span> <span class="n">Text</span><span class="p">),</span>
-    <span class="n">singlestoredb_full_text_indexes</span><span class="o">=</span><span class="p">[</span><span class="n">FullTextIndex</span><span class="p">(</span><span class="s1">&#39;content&#39;</span><span class="p">)],</span>
+    <span class="n">singlestoredb_full_text_index</span><span class="o">=</span><span class="p">[</span><span class="n">FullTextIndex</span><span class="p">(</span><span class="s1">&#39;content&#39;</span><span class="p">)],</span>
 <span class="p">)</span>
 <span class="c1"># Multiple columns with name</span>
 <span class="n">documents</span> <span class="o">=</span> <span class="n">Table</span><span class="p">(</span>
@@ -148,7 +148,7 @@ Version 2 or higher requires explicit specification.</p></li>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;id&#39;</span><span class="p">,</span> <span class="n">Integer</span><span class="p">,</span> <span class="n">primary_key</span><span class="o">=</span><span class="kc">True</span><span class="p">),</span>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">,</span> <span class="n">String</span><span class="p">(</span><span class="mi">200</span><span class="p">)),</span>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;body&#39;</span><span class="p">,</span> <span class="n">Text</span><span class="p">),</span>
-    <span class="n">singlestoredb_full_text_indexes</span><span class="o">=</span><span class="p">[</span>
+    <span class="n">singlestoredb_full_text_index</span><span class="o">=</span><span class="p">[</span>
         <span class="n">FullTextIndex</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">,</span> <span class="s1">&#39;body&#39;</span><span class="p">,</span> <span class="n">name</span><span class="o">=</span><span class="s1">&#39;ft_doc_search&#39;</span><span class="p">),</span>
     <span class="p">],</span>
 <span class="p">)</span>
@@ -164,7 +164,7 @@ Version 2 or higher requires explicit specification.</p></li>
     <span class="nb">id</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">Integer</span><span class="p">,</span> <span class="n">primary_key</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
     <span class="n">content</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">Text</span><span class="p">)</span>
     <span class="n">__table_args__</span> <span class="o">=</span> <span class="p">{</span>
-        <span class="s1">&#39;singlestoredb_full_text_indexes&#39;</span><span class="p">:</span> <span class="p">[</span><span class="n">FullTextIndex</span><span class="p">(</span><span class="s1">&#39;content&#39;</span><span class="p">)],</span>
+        <span class="s1">&#39;singlestoredb_full_text_index&#39;</span><span class="p">:</span> <span class="p">[</span><span class="n">FullTextIndex</span><span class="p">(</span><span class="s1">&#39;content&#39;</span><span class="p">)],</span>
     <span class="p">}</span>
 <span class="k">class</span> <span class="nc">Document</span><span class="p">(</span><span class="n">Base</span><span class="p">):</span>
     <span class="n">__tablename__</span> <span class="o">=</span> <span class="s1">&#39;documents&#39;</span>
@@ -172,7 +172,7 @@ Version 2 or higher requires explicit specification.</p></li>
     <span class="n">title</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">String</span><span class="p">(</span><span class="mi">200</span><span class="p">))</span>
     <span class="n">body</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">Text</span><span class="p">)</span>
     <span class="n">__table_args__</span> <span class="o">=</span> <span class="p">{</span>
-        <span class="s1">&#39;singlestoredb_full_text_indexes&#39;</span><span class="p">:</span> <span class="p">[</span>
+        <span class="s1">&#39;singlestoredb_full_text_index&#39;</span><span class="p">:</span> <span class="p">[</span>
             <span class="n">FullTextIndex</span><span class="p">(</span><span class="s1">&#39;title&#39;</span><span class="p">,</span> <span class="s1">&#39;body&#39;</span><span class="p">,</span> <span class="n">name</span><span class="o">=</span><span class="s1">&#39;ft_doc_search&#39;</span><span class="p">),</span>
         <span class="p">],</span>
     <span class="p">}</span>

--- a/docs/generated/sqlalchemy_singlestoredb.JSON.html
+++ b/docs/generated/sqlalchemy_singlestoredb.JSON.html
@@ -124,7 +124,7 @@ and querying.</p>
     <span class="nb">id</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">Integer</span><span class="p">,</span> <span class="n">primary_key</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
     <span class="n">tags</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">JSON</span><span class="p">)</span>
     <span class="n">__table_args__</span> <span class="o">=</span> <span class="p">{</span>
-        <span class="s1">&#39;singlestoredb_multi_value_indexes&#39;</span><span class="p">:</span> <span class="p">[</span><span class="n">MultiValueIndex</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">)],</span>
+        <span class="s1">&#39;singlestoredb_multi_value_index&#39;</span><span class="p">:</span> <span class="p">[</span><span class="n">MultiValueIndex</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">)],</span>
     <span class="p">}</span>
 </pre></div>
 </div>

--- a/docs/generated/sqlalchemy_singlestoredb.MultiValueIndex.html
+++ b/docs/generated/sqlalchemy_singlestoredb.MultiValueIndex.html
@@ -124,7 +124,7 @@ a dictionary that will be automatically JSON-serialized.</p></li>
     <span class="s1">&#39;articles&#39;</span><span class="p">,</span> <span class="n">metadata</span><span class="p">,</span>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;id&#39;</span><span class="p">,</span> <span class="n">Integer</span><span class="p">,</span> <span class="n">primary_key</span><span class="o">=</span><span class="kc">True</span><span class="p">),</span>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">,</span> <span class="n">JSON</span><span class="p">),</span>
-    <span class="n">singlestoredb_multi_value_indexes</span><span class="o">=</span><span class="p">[</span><span class="n">MultiValueIndex</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">)],</span>
+    <span class="n">singlestoredb_multi_value_index</span><span class="o">=</span><span class="p">[</span><span class="n">MultiValueIndex</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">)],</span>
 <span class="p">)</span>
 <span class="c1"># Multiple columns</span>
 <span class="n">products</span> <span class="o">=</span> <span class="n">Table</span><span class="p">(</span>
@@ -132,7 +132,7 @@ a dictionary that will be automatically JSON-serialized.</p></li>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;id&#39;</span><span class="p">,</span> <span class="n">Integer</span><span class="p">,</span> <span class="n">primary_key</span><span class="o">=</span><span class="kc">True</span><span class="p">),</span>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">,</span> <span class="n">JSON</span><span class="p">),</span>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;categories&#39;</span><span class="p">,</span> <span class="n">JSON</span><span class="p">),</span>
-    <span class="n">singlestoredb_multi_value_indexes</span><span class="o">=</span><span class="p">[</span>
+    <span class="n">singlestoredb_multi_value_index</span><span class="o">=</span><span class="p">[</span>
         <span class="n">MultiValueIndex</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">,</span> <span class="s1">&#39;categories&#39;</span><span class="p">),</span>
     <span class="p">],</span>
 <span class="p">)</span>
@@ -148,7 +148,7 @@ a dictionary that will be automatically JSON-serialized.</p></li>
     <span class="nb">id</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">Integer</span><span class="p">,</span> <span class="n">primary_key</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
     <span class="n">tags</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">JSON</span><span class="p">)</span>
     <span class="n">__table_args__</span> <span class="o">=</span> <span class="p">{</span>
-        <span class="s1">&#39;singlestoredb_multi_value_indexes&#39;</span><span class="p">:</span> <span class="p">[</span><span class="n">MultiValueIndex</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">)],</span>
+        <span class="s1">&#39;singlestoredb_multi_value_index&#39;</span><span class="p">:</span> <span class="p">[</span><span class="n">MultiValueIndex</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">)],</span>
     <span class="p">}</span>
 <span class="k">class</span> <span class="nc">Product</span><span class="p">(</span><span class="n">Base</span><span class="p">):</span>
     <span class="n">__tablename__</span> <span class="o">=</span> <span class="s1">&#39;products&#39;</span>
@@ -156,7 +156,7 @@ a dictionary that will be automatically JSON-serialized.</p></li>
     <span class="n">tags</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">JSON</span><span class="p">)</span>
     <span class="n">categories</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">JSON</span><span class="p">)</span>
     <span class="n">__table_args__</span> <span class="o">=</span> <span class="p">{</span>
-        <span class="s1">&#39;singlestoredb_multi_value_indexes&#39;</span><span class="p">:</span> <span class="p">[</span>
+        <span class="s1">&#39;singlestoredb_multi_value_index&#39;</span><span class="p">:</span> <span class="p">[</span>
             <span class="n">MultiValueIndex</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">,</span> <span class="s1">&#39;categories&#39;</span><span class="p">),</span>
         <span class="p">],</span>
     <span class="p">}</span>

--- a/docs/generated/sqlalchemy_singlestoredb.VectorKey.html
+++ b/docs/generated/sqlalchemy_singlestoredb.VectorKey.html
@@ -131,14 +131,14 @@ Common metric types: ‘EUCLIDEAN_DISTANCE’, ‘DOT_PRODUCT’, ‘COSINE_SIMI
     <span class="s1">&#39;embeddings&#39;</span><span class="p">,</span> <span class="n">metadata</span><span class="p">,</span>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;id&#39;</span><span class="p">,</span> <span class="n">Integer</span><span class="p">,</span> <span class="n">primary_key</span><span class="o">=</span><span class="kc">True</span><span class="p">),</span>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;embedding&#39;</span><span class="p">,</span> <span class="n">VECTOR</span><span class="p">(</span><span class="mi">1536</span><span class="p">)),</span>
-    <span class="n">singlestoredb_vector_keys</span><span class="o">=</span><span class="p">[</span><span class="n">VectorKey</span><span class="p">(</span><span class="s1">&#39;embedding&#39;</span><span class="p">)],</span>
+    <span class="n">singlestoredb_vector_key</span><span class="o">=</span><span class="p">[</span><span class="n">VectorKey</span><span class="p">(</span><span class="s1">&#39;embedding&#39;</span><span class="p">)],</span>
 <span class="p">)</span>
 <span class="c1"># Named vector index with options</span>
 <span class="n">documents</span> <span class="o">=</span> <span class="n">Table</span><span class="p">(</span>
     <span class="s1">&#39;documents&#39;</span><span class="p">,</span> <span class="n">metadata</span><span class="p">,</span>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;id&#39;</span><span class="p">,</span> <span class="n">Integer</span><span class="p">,</span> <span class="n">primary_key</span><span class="o">=</span><span class="kc">True</span><span class="p">),</span>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;embedding&#39;</span><span class="p">,</span> <span class="n">VECTOR</span><span class="p">(</span><span class="mi">768</span><span class="p">)),</span>
-    <span class="n">singlestoredb_vector_keys</span><span class="o">=</span><span class="p">[</span>
+    <span class="n">singlestoredb_vector_key</span><span class="o">=</span><span class="p">[</span>
         <span class="n">VectorKey</span><span class="p">(</span>
             <span class="s1">&#39;embedding&#39;</span><span class="p">,</span>
             <span class="n">name</span><span class="o">=</span><span class="s1">&#39;doc_vec_idx&#39;</span><span class="p">,</span>
@@ -158,14 +158,14 @@ Common metric types: ‘EUCLIDEAN_DISTANCE’, ‘DOT_PRODUCT’, ‘COSINE_SIMI
     <span class="nb">id</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">Integer</span><span class="p">,</span> <span class="n">primary_key</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
     <span class="n">embedding</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">VECTOR</span><span class="p">(</span><span class="mi">1536</span><span class="p">))</span>
     <span class="n">__table_args__</span> <span class="o">=</span> <span class="p">{</span>
-        <span class="s1">&#39;singlestoredb_vector_keys&#39;</span><span class="p">:</span> <span class="p">[</span><span class="n">VectorKey</span><span class="p">(</span><span class="s1">&#39;embedding&#39;</span><span class="p">)],</span>
+        <span class="s1">&#39;singlestoredb_vector_key&#39;</span><span class="p">:</span> <span class="p">[</span><span class="n">VectorKey</span><span class="p">(</span><span class="s1">&#39;embedding&#39;</span><span class="p">)],</span>
     <span class="p">}</span>
 <span class="k">class</span> <span class="nc">Document</span><span class="p">(</span><span class="n">Base</span><span class="p">):</span>
     <span class="n">__tablename__</span> <span class="o">=</span> <span class="s1">&#39;documents&#39;</span>
     <span class="nb">id</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">Integer</span><span class="p">,</span> <span class="n">primary_key</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
     <span class="n">embedding</span> <span class="o">=</span> <span class="n">Column</span><span class="p">(</span><span class="n">VECTOR</span><span class="p">(</span><span class="mi">768</span><span class="p">))</span>
     <span class="n">__table_args__</span> <span class="o">=</span> <span class="p">{</span>
-        <span class="s1">&#39;singlestoredb_vector_keys&#39;</span><span class="p">:</span> <span class="p">[</span>
+        <span class="s1">&#39;singlestoredb_vector_key&#39;</span><span class="p">:</span> <span class="p">[</span>
             <span class="n">VectorKey</span><span class="p">(</span>
                 <span class="s1">&#39;embedding&#39;</span><span class="p">,</span>
                 <span class="n">name</span><span class="o">=</span><span class="s1">&#39;doc_vec_idx&#39;</span><span class="p">,</span>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -134,10 +134,10 @@ SQLAlchemy dialect.</p>
     <span class="n">Column</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">,</span> <span class="n">JSON</span><span class="p">),</span>
     <span class="n">singlestoredb_table_type</span><span class="o">=</span><span class="n">ColumnStore</span><span class="p">(),</span>
     <span class="n">singlestoredb_shard_key</span><span class="o">=</span><span class="n">ShardKey</span><span class="p">(</span><span class="s1">&#39;id&#39;</span><span class="p">),</span>
-    <span class="n">singlestoredb_vector_keys</span><span class="o">=</span><span class="p">[</span>
+    <span class="n">singlestoredb_vector_key</span><span class="o">=</span><span class="p">[</span>
         <span class="n">VectorKey</span><span class="p">(</span><span class="s1">&#39;embedding&#39;</span><span class="p">,</span> <span class="n">index_options</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;metric_type&#39;</span><span class="p">:</span> <span class="s1">&#39;COSINE_SIMILARITY&#39;</span><span class="p">}),</span>
     <span class="p">],</span>
-    <span class="n">singlestoredb_multi_value_indexes</span><span class="o">=</span><span class="p">[</span><span class="n">MultiValueIndex</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">)],</span>
+    <span class="n">singlestoredb_multi_value_index</span><span class="o">=</span><span class="p">[</span><span class="n">MultiValueIndex</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">)],</span>
 <span class="p">)</span>
 <span class="c1"># Create all tables</span>
 <span class="n">metadata</span><span class="o">.</span><span class="n">create_all</span><span class="p">(</span><span class="n">engine</span><span class="p">)</span>
@@ -178,10 +178,10 @@ SQLAlchemy dialect.</p>
     <span class="n">__table_args__</span> <span class="o">=</span> <span class="p">{</span>
         <span class="s1">&#39;singlestoredb_table_type&#39;</span><span class="p">:</span> <span class="n">ColumnStore</span><span class="p">(),</span>
         <span class="s1">&#39;singlestoredb_shard_key&#39;</span><span class="p">:</span> <span class="n">ShardKey</span><span class="p">(</span><span class="s1">&#39;id&#39;</span><span class="p">),</span>
-        <span class="s1">&#39;singlestoredb_vector_keys&#39;</span><span class="p">:</span> <span class="p">[</span>
+        <span class="s1">&#39;singlestoredb_vector_key&#39;</span><span class="p">:</span> <span class="p">[</span>
             <span class="n">VectorKey</span><span class="p">(</span><span class="s1">&#39;embedding&#39;</span><span class="p">,</span> <span class="n">index_options</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;metric_type&#39;</span><span class="p">:</span> <span class="s1">&#39;COSINE_SIMILARITY&#39;</span><span class="p">}),</span>
         <span class="p">],</span>
-        <span class="s1">&#39;singlestoredb_multi_value_indexes&#39;</span><span class="p">:</span> <span class="p">[</span><span class="n">MultiValueIndex</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">)],</span>
+        <span class="s1">&#39;singlestoredb_multi_value_index&#39;</span><span class="p">:</span> <span class="p">[</span><span class="n">MultiValueIndex</span><span class="p">(</span><span class="s1">&#39;tags&#39;</span><span class="p">)],</span>
     <span class="p">}</span>
 <span class="c1"># Create all tables</span>
 <span class="n">Base</span><span class="o">.</span><span class="n">metadata</span><span class="o">.</span><span class="n">create_all</span><span class="p">(</span><span class="n">engine</span><span class="p">)</span>

--- a/docs/src/getting-started.rst
+++ b/docs/src/getting-started.rst
@@ -74,10 +74,10 @@ Use SQLAlchemy's Table construct with SingleStoreDB-specific options:
         Column('tags', JSON),
         singlestoredb_table_type=ColumnStore(),
         singlestoredb_shard_key=ShardKey('id'),
-        singlestoredb_vector_keys=[
+        singlestoredb_vector_key=[
             VectorKey('embedding', index_options={'metric_type': 'COSINE_SIMILARITY'}),
         ],
-        singlestoredb_multi_value_indexes=[MultiValueIndex('tags')],
+        singlestoredb_multi_value_index=[MultiValueIndex('tags')],
     )
 
     # Create all tables
@@ -129,10 +129,10 @@ Use SQLAlchemy's declarative ORM with ``__table_args__``:
         __table_args__ = {
             'singlestoredb_table_type': ColumnStore(),
             'singlestoredb_shard_key': ShardKey('id'),
-            'singlestoredb_vector_keys': [
+            'singlestoredb_vector_key': [
                 VectorKey('embedding', index_options={'metric_type': 'COSINE_SIMILARITY'}),
             ],
-            'singlestoredb_multi_value_indexes': [MultiValueIndex('tags')],
+            'singlestoredb_multi_value_index': [MultiValueIndex('tags')],
         }
 
     # Create all tables

--- a/sqlalchemy_singlestoredb/ddlelement.py
+++ b/sqlalchemy_singlestoredb/ddlelement.py
@@ -604,7 +604,7 @@ class VectorKey(DDLElement):
             'embeddings', metadata,
             Column('id', Integer, primary_key=True),
             Column('embedding', VECTOR(1536)),
-            singlestoredb_vector_keys=[VectorKey('embedding')],
+            singlestoredb_vector_key=[VectorKey('embedding')],
         )
 
         # Named vector index with options
@@ -612,7 +612,7 @@ class VectorKey(DDLElement):
             'documents', metadata,
             Column('id', Integer, primary_key=True),
             Column('embedding', VECTOR(768)),
-            singlestoredb_vector_keys=[
+            singlestoredb_vector_key=[
                 VectorKey(
                     'embedding',
                     name='doc_vec_idx',
@@ -638,7 +638,7 @@ class VectorKey(DDLElement):
             embedding = Column(VECTOR(1536))
 
             __table_args__ = {
-                'singlestoredb_vector_keys': [VectorKey('embedding')],
+                'singlestoredb_vector_key': [VectorKey('embedding')],
             }
 
         class Document(Base):
@@ -648,7 +648,7 @@ class VectorKey(DDLElement):
             embedding = Column(VECTOR(768))
 
             __table_args__ = {
-                'singlestoredb_vector_keys': [
+                'singlestoredb_vector_key': [
                     VectorKey(
                         'embedding',
                         name='doc_vec_idx',
@@ -796,7 +796,7 @@ class MultiValueIndex(DDLElement):
             'articles', metadata,
             Column('id', Integer, primary_key=True),
             Column('tags', JSON),
-            singlestoredb_multi_value_indexes=[MultiValueIndex('tags')],
+            singlestoredb_multi_value_index=[MultiValueIndex('tags')],
         )
 
         # Multiple columns
@@ -805,7 +805,7 @@ class MultiValueIndex(DDLElement):
             Column('id', Integer, primary_key=True),
             Column('tags', JSON),
             Column('categories', JSON),
-            singlestoredb_multi_value_indexes=[
+            singlestoredb_multi_value_index=[
                 MultiValueIndex('tags', 'categories'),
             ],
         )
@@ -827,7 +827,7 @@ class MultiValueIndex(DDLElement):
             tags = Column(JSON)
 
             __table_args__ = {
-                'singlestoredb_multi_value_indexes': [MultiValueIndex('tags')],
+                'singlestoredb_multi_value_index': [MultiValueIndex('tags')],
             }
 
         class Product(Base):
@@ -838,7 +838,7 @@ class MultiValueIndex(DDLElement):
             categories = Column(JSON)
 
             __table_args__ = {
-                'singlestoredb_multi_value_indexes': [
+                'singlestoredb_multi_value_index': [
                     MultiValueIndex('tags', 'categories'),
                 ],
             }
@@ -979,7 +979,7 @@ class FullTextIndex(DDLElement):
             'articles', metadata,
             Column('id', Integer, primary_key=True),
             Column('content', Text),
-            singlestoredb_full_text_indexes=[FullTextIndex('content')],
+            singlestoredb_full_text_index=[FullTextIndex('content')],
         )
 
         # Multiple columns with name
@@ -988,7 +988,7 @@ class FullTextIndex(DDLElement):
             Column('id', Integer, primary_key=True),
             Column('title', String(200)),
             Column('body', Text),
-            singlestoredb_full_text_indexes=[
+            singlestoredb_full_text_index=[
                 FullTextIndex('title', 'body', name='ft_doc_search'),
             ],
         )
@@ -1010,7 +1010,7 @@ class FullTextIndex(DDLElement):
             content = Column(Text)
 
             __table_args__ = {
-                'singlestoredb_full_text_indexes': [FullTextIndex('content')],
+                'singlestoredb_full_text_index': [FullTextIndex('content')],
             }
 
         class Document(Base):
@@ -1021,7 +1021,7 @@ class FullTextIndex(DDLElement):
             body = Column(Text)
 
             __table_args__ = {
-                'singlestoredb_full_text_indexes': [
+                'singlestoredb_full_text_index': [
                     FullTextIndex('title', 'body', name='ft_doc_search'),
                 ],
             }

--- a/sqlalchemy_singlestoredb/dtypes.py
+++ b/sqlalchemy_singlestoredb/dtypes.py
@@ -81,7 +81,7 @@ class JSON(mybase.JSON):
             tags = Column(JSON)
 
             __table_args__ = {
-                'singlestoredb_multi_value_indexes': [MultiValueIndex('tags')],
+                'singlestoredb_multi_value_index': [MultiValueIndex('tags')],
             }
 
     """


### PR DESCRIPTION
## Context

The [Creating Tables tutorial](https://sqlalchemy-singlestoredb.labs.singlestore.com/getting-started.html#creating-tables-core-api) uses plural SingleStoreDB table argument names e.g., `singlestoredb_vector_keys`, `singlestoredb_multi_value_indexes`, etc. that are inconsistent with the DDL implementation.

https://github.com/singlestore-labs/sqlalchemy-singlestoredb/blob/dd67b4a8dd37a365c91c4ca40d7ac3c298724299/sqlalchemy_singlestoredb/base.py#L237-L251

This caused SQLAlchemy to emit invalid table options instead of the expected index clauses.

## Changes

- Replace plural options with the supported singular forms:
  - `singlestoredb_vector_key`
  - `singlestoredb_multi_value_index`
  - `singlestoredb_full_text_index`
- Update README, API docstrings, getting-started guide, and generated documentation.

## Related issue

Closes #15

## Testing

- `pre-commit run --all-files` passes.
- 38 relevant non-database tests pass.
- Confirmed singular dialect option names compile to `VECTOR INDEX` and `MULTI VALUE INDEX` clauses instead of invalid table options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only renames aligned with existing `base.py` option names; no library behavior change in the diff.
> 
> **Overview**
> Documentation and examples now use the **singular** `Table` / `__table_args__` keys the dialect actually recognizes, instead of incorrect plural names that could emit invalid table options instead of index DDL.
> 
> Renames across README, getting-started guides, API docstrings in `ddlelement.py` / `dtypes.py`, and generated Sphinx HTML: `singlestoredb_vector_keys` → `singlestoredb_vector_key`, `singlestoredb_multi_value_indexes` → `singlestoredb_multi_value_index`, and `singlestoredb_full_text_indexes` → `singlestoredb_full_text_index`. No runtime code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f1e692e9078951fbc810f44cb8e7829c96efca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->